### PR TITLE
go mod and docker-compose support

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,18 +6,18 @@
 
 [link-prevue Demo Repo](https://github.com/nivaldomartinez/link-prevue-demo)
 
-## Install GoDep
+## Usage
 
-In the root project folder run the following command
+In the root project folder run the following command:
 
 ```sh
-$ go get github.com/tools/godep
+$ go run main.go
 ```
 
-and run
+or with the docker-compose:
 
 ```sh
-$ godep save
+docker-compose up
 ```
 
 ## Deploy on Heroku

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+version: '3.2'
+services:
+  api:
+    image: golang:1.17
+    volumes:
+      - "./:/code"
+    ports:
+      - "4747:4747"
+    working_dir: /code
+    entrypoint: go run main.go

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,10 @@
+module github.com/sebastianwebber/link-preview-api
+
+go 1.16
+
+require (
+	github.com/badoux/goscraper v0.0.0-20190827161153-36995ce6b19f
+	github.com/gorilla/handlers v1.5.1
+	github.com/gorilla/mux v1.8.0
+	golang.org/x/net v0.0.0-20210825183410-e898025ed96a // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,16 @@
+github.com/badoux/goscraper v0.0.0-20190827161153-36995ce6b19f h1:K7yQFgSzse/bjP0DaNlmgdlg8u0HiIQax0HdTGnaMaY=
+github.com/badoux/goscraper v0.0.0-20190827161153-36995ce6b19f/go.mod h1:5iU5AiceCVP7wmrAIn/9YhJzvmErX/GihV/T2o5QUpM=
+github.com/felixge/httpsnoop v1.0.1 h1:lvB5Jl89CsZtGIWuTcDM1E/vkVs49/Ml7JJe07l8SPQ=
+github.com/felixge/httpsnoop v1.0.1/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
+github.com/gorilla/handlers v1.5.1 h1:9lRY6j8DEeeBT10CvO9hGW0gmky0BprnvDI5vfhUHH4=
+github.com/gorilla/handlers v1.5.1/go.mod h1:t8XrUpc4KVXb7HGyJ4/cEnwQiaxrX/hz1Zv/4g96P1Q=
+github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
+github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
+golang.org/x/net v0.0.0-20210825183410-e898025ed96a h1:bRuuGXV8wwSdGTB+CtJf+FjgO1APK1CoO39T4BN/XBw=
+golang.org/x/net v0.0.0-20210825183410-e898025ed96a/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
+golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
+golang.org/x/text v0.3.6 h1:aRYxNxv6iGQlyVaZmk6ZgYEDa+Jg18DxebPSrd6bg1M=
+golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=

--- a/main.go
+++ b/main.go
@@ -2,20 +2,21 @@ package main
 
 import (
 	"encoding/json"
-	"github.com/gorilla/mux"
 	"fmt"
 	"io"
-	"os"
 	"net/http"
+	"os"
+
 	"github.com/badoux/goscraper"
 	"github.com/gorilla/handlers"
+	"github.com/gorilla/mux"
 )
 
 type Preview struct {
-    Url   	  string   `json:"url"`
-    Title         string   `json:"title"`
-    Description   string   `json:"description"`
-    Images      []string   `json:"images"`
+	Url         string   `json:"url"`
+	Title       string   `json:"title"`
+	Description string   `json:"description"`
+	Images      []string `json:"images"`
 }
 
 func getUrlData(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
This PR adds support to run the project with the docker-compose and also removed the dependency of the `go dep` to use the "latest" go modules.

Update the readme with details.

Tested with docker and go 1.17 and also in the mac with go 1.16.

Hoping tha it helps.

Regards,
Sebastian